### PR TITLE
change search api "http://search.twitter.com" to https

### DIFF
--- a/app/helpers/twitter.js
+++ b/app/helpers/twitter.js
@@ -130,7 +130,7 @@ TwitterAPI.prototype = {
 	},
 	search: function(query, callback) {
 		// Query can be either a string or an object literal with named parameters in it
-		var url = 'http://search.twitter.com/search.json';
+		var url = 'https://search.twitter.com/search.json';
 		var args = {"result_type":"mixed","rpp":"150"};
 
 		if (typeof(query) === 'string') {


### PR DESCRIPTION
change search api "http://search.twitter.com" to https which chinese users can across firewall by changing hosts.
