### PR TITLE
Fix retweet from freshly created account

### DIFF
--- a/app/helpers/tweet.js
+++ b/app/helpers/tweet.js
@@ -388,9 +388,13 @@ TweetHelper.prototype = {
 		// Finds out if you retweeted this tweet
 		var r = false;
 
-		for (var i=0; i < user.retweeted.length; i++) {
-			if (user.retweeted[i] === tweet.id_str) {
-				r = true;
+		if (user.retweeted === undefined) {
+			user.retweeted = [];
+		} else {
+			for (var i=0; i < user.retweeted.length; i++) {
+				if (user.retweeted[i] === tweet.id_str) {
+					r = true;
+				}
 			}
 		}
 


### PR DESCRIPTION
If you just created an account, the user.retweeted list will be undefined. If it is and you want to retweet, an exception is thrown. Check to see if the list does not exist. If so, create it, then move along.
